### PR TITLE
ビルド後にuseHeadでcss変数が生成されなかったのを修正

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -14,6 +14,7 @@ import translation from 'zod-i18n-map/locales/ja/zod.json';
 import VueDatePicker from '@vuepic/vue-datepicker';
 import '@vuepic/vue-datepicker/dist/main.css';
 import useTheme from '../src/composables/useTheme';
+import { createHead } from '@unhead/vue';
 
 const customErrorMap: z.ZodErrorMap = (issue, ctx) => {
     switch (issue.code) {
@@ -41,6 +42,8 @@ z.setErrorMap(customErrorMap);
 setup((app) => {
     app.component('VueDatePicker', VueDatePicker);
 
+    const head = createHead();
+    app.use(head);
     app.use(useTheme);
     const { currentTheme, setTheme } = useTheme();
     // 初期style設定

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "@acab/reset.css": "^0.10.0",
+    "@unhead/vue": "^1.11.19",
     "@vee-validate/rules": "^4.13.2",
     "@vee-validate/zod": "^4.13.2",
     "@vuepic/vue-datepicker": "^8.5.1",
@@ -64,7 +65,6 @@
     "i18next": "^23.12.2",
     "lucide-vue-next": "^0.356.0",
     "pinia": "^2.2.2",
-    "unhead": "^1.9.12",
     "vee-validate": "^4.13.2",
     "vue": "^3.4.27",
     "vue-router": "^4.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@acab/reset.css':
         specifier: ^0.10.0
         version: 0.10.0
+      '@unhead/vue':
+        specifier: ^1.11.19
+        version: 1.11.19(vue@3.4.27(typescript@5.4.5))
       '@vee-validate/rules':
         specifier: ^4.13.2
         version: 4.13.2(vue@3.4.27(typescript@5.4.5))
@@ -32,9 +35,6 @@ importers:
       pinia:
         specifier: ^2.2.2
         version: 2.2.2(typescript@5.4.5)(vue@3.4.27(typescript@5.4.5))
-      unhead:
-        specifier: ^1.9.12
-        version: 1.9.12
       vee-validate:
         specifier: ^4.13.2
         version: 4.13.2(vue@3.4.27(typescript@5.4.5))
@@ -1812,14 +1812,19 @@ packages:
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
 
-  '@unhead/dom@1.9.12':
-    resolution: {integrity: sha512-3MY1TbZmEjGNZapi3wvJW0vWNS2CLKHt7/m57sScDHCNvNBe1mTwrIOhtZFDgAndhml2EVQ68RMa0Vhum/M+cw==}
+  '@unhead/dom@1.11.19':
+    resolution: {integrity: sha512-udkgITdIblEWH3hsoFQMKW+6QXNO2qFZlZ2FI37bVAplQSnK/PytTPt/5oA1GWkoVwT0DsQNGHbU6kOg/3SlNg==}
 
-  '@unhead/schema@1.9.12':
-    resolution: {integrity: sha512-ue2FKyIZKsuZDpWJBMlBGwMm4s+vFeU3NUWsNt8Z+2JkOUIqO/VG43LxNgY1M595bOS71Gdxk+G9VtzfKJ5uEA==}
+  '@unhead/schema@1.11.19':
+    resolution: {integrity: sha512-7VhYHWK7xHgljdv+C01MepCSYZO2v6OhgsfKWPxRQBDDGfUKCUaChox0XMq3tFvXP6u4zSp6yzcDw2yxCfVMwg==}
 
-  '@unhead/shared@1.9.12':
-    resolution: {integrity: sha512-72wlLXG3FP3sXUrwd42Uv8jYpHSg4R6IFJcsl+QisRjKM89JnjOFSw1DqWO4IOftW5xOxS4J5v7SQyJ4NJo7Bw==}
+  '@unhead/shared@1.11.19':
+    resolution: {integrity: sha512-UYE9EIeQLJOhx8vC71bWGkAGY4Zzq/H8qYlihowUg4NiFOfL+KKMnj96datb74PRxSDvHac9V3OLktNcsX2NuA==}
+
+  '@unhead/vue@1.11.19':
+    resolution: {integrity: sha512-/XATTP8wVLs3+2Pkj2crvr/Z55nybVQyOwISh+sAlr/48/9n3jGNiCZHKpHgL4MpOnGT4krwzWzbfhBO/G2BSQ==}
+    peerDependencies:
+      vue: '>=2.7 || >=3'
 
   '@vee-validate/rules@4.13.2':
     resolution: {integrity: sha512-NrmjxXw/gZQVhjgwIdEOeRYxn74I/3BYXTuExdwbpCPVgFh0pjTQx9aPGkVBnueeszVqO2LfWyKUpvwSWLPXRA==}
@@ -3438,6 +3443,9 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
+  packrup@0.1.2:
+    resolution: {integrity: sha512-ZcKU7zrr5GlonoS9cxxrb5HVswGnyj6jQvwFBa6p5VFw7G71VAHcUKL5wyZSU/ECtPM/9gacWxy2KFQKt1gMNA==}
+
   pako@0.2.9:
     resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
 
@@ -4148,8 +4156,8 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
-  unhead@1.9.12:
-    resolution: {integrity: sha512-s6VxcTV45hy8c/IioKQOonFnAO+kBOSpgDfqEHhnU0YVSQYaRPEp9pzW1qSPf0lx+bg9RKeOQyNNbSGGUP26aQ==}
+  unhead@1.11.19:
+    resolution: {integrity: sha512-O5AYb3+xUOzBlwDmPfC/DgGp9rDMoGkB4gFkhoaz8IonQqP8W8qqetxYf5ZyEdntvXnFsMWS8lZF//5176xo6Q==}
 
   unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
@@ -4317,6 +4325,9 @@ packages:
 
   vue-component-type-helpers@2.0.29:
     resolution: {integrity: sha512-58i+ZhUAUpwQ+9h5Hck0D+jr1qbYl4voRt5KffBx8qzELViQ4XdT/Tuo+mzq8u63teAG8K0lLaOiL5ofqW38rg==}
+
+  vue-component-type-helpers@2.2.4:
+    resolution: {integrity: sha512-F66p0XLbAu92BRz6kakHyAcaUSF7HWpWX/THCqL0TxySSj7z/nok5UUMohfNkkCm1pZtawsdzoJ4p1cjNqCx0Q==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -6451,7 +6462,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.4.27(typescript@5.4.5)
-      vue-component-type-helpers: 2.0.29
+      vue-component-type-helpers: 2.2.4
     transitivePeerDependencies:
       - encoding
       - prettier
@@ -6653,19 +6664,28 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@unhead/dom@1.9.12':
+  '@unhead/dom@1.11.19':
     dependencies:
-      '@unhead/schema': 1.9.12
-      '@unhead/shared': 1.9.12
+      '@unhead/schema': 1.11.19
+      '@unhead/shared': 1.11.19
 
-  '@unhead/schema@1.9.12':
+  '@unhead/schema@1.11.19':
     dependencies:
       hookable: 5.5.3
       zhead: 2.2.4
 
-  '@unhead/shared@1.9.12':
+  '@unhead/shared@1.11.19':
     dependencies:
-      '@unhead/schema': 1.9.12
+      '@unhead/schema': 1.11.19
+      packrup: 0.1.2
+
+  '@unhead/vue@1.11.19(vue@3.4.27(typescript@5.4.5))':
+    dependencies:
+      '@unhead/schema': 1.11.19
+      '@unhead/shared': 1.11.19
+      hookable: 5.5.3
+      unhead: 1.11.19
+      vue: 3.4.27(typescript@5.4.5)
 
   '@vee-validate/rules@4.13.2(vue@3.4.27(typescript@5.4.5))':
     dependencies:
@@ -8390,6 +8410,8 @@ snapshots:
 
   p-try@2.2.0: {}
 
+  packrup@0.1.2: {}
+
   pako@0.2.9: {}
 
   parent-module@1.0.1:
@@ -9137,11 +9159,11 @@ snapshots:
 
   undici-types@5.26.5: {}
 
-  unhead@1.9.12:
+  unhead@1.11.19:
     dependencies:
-      '@unhead/dom': 1.9.12
-      '@unhead/schema': 1.9.12
-      '@unhead/shared': 1.9.12
+      '@unhead/dom': 1.11.19
+      '@unhead/schema': 1.11.19
+      '@unhead/shared': 1.11.19
       hookable: 5.5.3
 
   unicode-canonical-property-names-ecmascript@2.0.0: {}
@@ -9285,6 +9307,8 @@ snapshots:
       typescript: 5.4.5
 
   vue-component-type-helpers@2.0.29: {}
+
+  vue-component-type-helpers@2.2.4: {}
 
   vue-demi@0.14.10(vue@3.4.27(typescript@5.4.5)):
     dependencies:

--- a/src/composables/useTheme.ts
+++ b/src/composables/useTheme.ts
@@ -6,7 +6,7 @@
  */
 
 import { ref, watch } from 'vue';
-import { createHead, useHead } from 'unhead';
+import { useHead } from '@unhead/vue';
 import { toKebabCase } from '@/assets/ts/formatter';
 import merge from 'lodash.merge';
 
@@ -68,9 +68,6 @@ export interface MiTheme
     status?: MiThemeOptionStatus;
     theme?: MiThemeOptionTheme;
 }
-
-// 初期化
-createHead();
 
 // global state
 const currentTheme = ref<themeId>(


### PR DESCRIPTION
`run dev`では正常にcss変数が生成されてたが、previewやbuild後の通常デプロイでは生成されていなかったのを修正